### PR TITLE
Client auth

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -8,6 +8,8 @@
 			"name": "resourcehubfrontend",
 			"version": "0.0.1",
 			"dependencies": {
+				"@supabase/ssr": "^0.6.1",
+				"@supabase/supabase-js": "^2.49.8",
 				"dotenv": "^16.5.0"
 			},
 			"devDependencies": {
@@ -1109,6 +1111,101 @@
 				"win32"
 			]
 		},
+		"node_modules/@supabase/auth-js": {
+			"version": "2.69.1",
+			"resolved": "https://registry.npmjs.org/@supabase/auth-js/-/auth-js-2.69.1.tgz",
+			"integrity": "sha512-FILtt5WjCNzmReeRLq5wRs3iShwmnWgBvxHfqapC/VoljJl+W8hDAyFmf1NVw3zH+ZjZ05AKxiKxVeb0HNWRMQ==",
+			"license": "MIT",
+			"dependencies": {
+				"@supabase/node-fetch": "^2.6.14"
+			}
+		},
+		"node_modules/@supabase/functions-js": {
+			"version": "2.4.4",
+			"resolved": "https://registry.npmjs.org/@supabase/functions-js/-/functions-js-2.4.4.tgz",
+			"integrity": "sha512-WL2p6r4AXNGwop7iwvul2BvOtuJ1YQy8EbOd0dhG1oN1q8el/BIRSFCFnWAMM/vJJlHWLi4ad22sKbKr9mvjoA==",
+			"license": "MIT",
+			"dependencies": {
+				"@supabase/node-fetch": "^2.6.14"
+			}
+		},
+		"node_modules/@supabase/node-fetch": {
+			"version": "2.6.15",
+			"resolved": "https://registry.npmjs.org/@supabase/node-fetch/-/node-fetch-2.6.15.tgz",
+			"integrity": "sha512-1ibVeYUacxWYi9i0cf5efil6adJ9WRyZBLivgjs+AUpewx1F3xPi7gLgaASI2SmIQxPoCEjAsLAzKPgMJVgOUQ==",
+			"license": "MIT",
+			"dependencies": {
+				"whatwg-url": "^5.0.0"
+			},
+			"engines": {
+				"node": "4.x || >=6.0.0"
+			}
+		},
+		"node_modules/@supabase/postgrest-js": {
+			"version": "1.19.4",
+			"resolved": "https://registry.npmjs.org/@supabase/postgrest-js/-/postgrest-js-1.19.4.tgz",
+			"integrity": "sha512-O4soKqKtZIW3olqmbXXbKugUtByD2jPa8kL2m2c1oozAO11uCcGrRhkZL0kVxjBLrXHE0mdSkFsMj7jDSfyNpw==",
+			"license": "MIT",
+			"dependencies": {
+				"@supabase/node-fetch": "^2.6.14"
+			}
+		},
+		"node_modules/@supabase/realtime-js": {
+			"version": "2.11.2",
+			"resolved": "https://registry.npmjs.org/@supabase/realtime-js/-/realtime-js-2.11.2.tgz",
+			"integrity": "sha512-u/XeuL2Y0QEhXSoIPZZwR6wMXgB+RQbJzG9VErA3VghVt7uRfSVsjeqd7m5GhX3JR6dM/WRmLbVR8URpDWG4+w==",
+			"license": "MIT",
+			"dependencies": {
+				"@supabase/node-fetch": "^2.6.14",
+				"@types/phoenix": "^1.5.4",
+				"@types/ws": "^8.5.10",
+				"ws": "^8.18.0"
+			}
+		},
+		"node_modules/@supabase/ssr": {
+			"version": "0.6.1",
+			"resolved": "https://registry.npmjs.org/@supabase/ssr/-/ssr-0.6.1.tgz",
+			"integrity": "sha512-QtQgEMvaDzr77Mk3vZ3jWg2/y+D8tExYF7vcJT+wQ8ysuvOeGGjYbZlvj5bHYsj/SpC0bihcisnwPrM4Gp5G4g==",
+			"license": "MIT",
+			"dependencies": {
+				"cookie": "^1.0.1"
+			},
+			"peerDependencies": {
+				"@supabase/supabase-js": "^2.43.4"
+			}
+		},
+		"node_modules/@supabase/ssr/node_modules/cookie": {
+			"version": "1.0.2",
+			"resolved": "https://registry.npmjs.org/cookie/-/cookie-1.0.2.tgz",
+			"integrity": "sha512-9Kr/j4O16ISv8zBBhJoi4bXOYNTkFLOqSL3UDB0njXxCXNezjeyVrJyGOWtgfs/q2km1gwBcfH8q1yEGoMYunA==",
+			"license": "MIT",
+			"engines": {
+				"node": ">=18"
+			}
+		},
+		"node_modules/@supabase/storage-js": {
+			"version": "2.7.1",
+			"resolved": "https://registry.npmjs.org/@supabase/storage-js/-/storage-js-2.7.1.tgz",
+			"integrity": "sha512-asYHcyDR1fKqrMpytAS1zjyEfvxuOIp1CIXX7ji4lHHcJKqyk+sLl/Vxgm4sN6u8zvuUtae9e4kDxQP2qrwWBA==",
+			"license": "MIT",
+			"dependencies": {
+				"@supabase/node-fetch": "^2.6.14"
+			}
+		},
+		"node_modules/@supabase/supabase-js": {
+			"version": "2.49.8",
+			"resolved": "https://registry.npmjs.org/@supabase/supabase-js/-/supabase-js-2.49.8.tgz",
+			"integrity": "sha512-zzBQLgS/jZs7btWcIAc7V5yfB+juG7h0AXxKowMJuySsO5vK+F7Vp+HCa07Z+tu9lZtr3sT9fofkc86bdylmtw==",
+			"license": "MIT",
+			"dependencies": {
+				"@supabase/auth-js": "2.69.1",
+				"@supabase/functions-js": "2.4.4",
+				"@supabase/node-fetch": "2.6.15",
+				"@supabase/postgrest-js": "1.19.4",
+				"@supabase/realtime-js": "2.11.2",
+				"@supabase/storage-js": "2.7.1"
+			}
+		},
 		"node_modules/@sveltejs/acorn-typescript": {
 			"version": "1.0.5",
 			"resolved": "https://registry.npmjs.org/@sveltejs/acorn-typescript/-/acorn-typescript-1.0.5.tgz",
@@ -1526,10 +1623,24 @@
 			"version": "22.15.12",
 			"resolved": "https://registry.npmjs.org/@types/node/-/node-22.15.12.tgz",
 			"integrity": "sha512-K0fpC/ZVeb8G9rm7bH7vI0KAec4XHEhBam616nVJCV51bKzJ6oA3luG4WdKoaztxe70QaNjS/xBmcDLmr4PiGw==",
-			"dev": true,
 			"license": "MIT",
 			"dependencies": {
 				"undici-types": "~6.21.0"
+			}
+		},
+		"node_modules/@types/phoenix": {
+			"version": "1.6.6",
+			"resolved": "https://registry.npmjs.org/@types/phoenix/-/phoenix-1.6.6.tgz",
+			"integrity": "sha512-PIzZZlEppgrpoT2QgbnDU+MMzuR6BbCjllj0bM70lWoejMeNJAxCchxnv7J3XFkI8MpygtRpzXrIlmWUBclP5A==",
+			"license": "MIT"
+		},
+		"node_modules/@types/ws": {
+			"version": "8.18.1",
+			"resolved": "https://registry.npmjs.org/@types/ws/-/ws-8.18.1.tgz",
+			"integrity": "sha512-ThVF6DCVhA8kUGy+aazFQ4kXQ7E1Ty7A3ypFOe0IcJV8O/M511G99AW24irKrW56Wt44yG9+ij8FaqoBGkuBXg==",
+			"license": "MIT",
+			"dependencies": {
+				"@types/node": "*"
 			}
 		},
 		"node_modules/@typescript-eslint/eslint-plugin": {
@@ -4741,6 +4852,12 @@
 				"node": ">=6"
 			}
 		},
+		"node_modules/tr46": {
+			"version": "0.0.3",
+			"resolved": "https://registry.npmjs.org/tr46/-/tr46-0.0.3.tgz",
+			"integrity": "sha512-N3WMsuqV66lT30CrXNbEjx4GEwlow3v6rr4mCcv6prnfwhS01rkgyFdjPNBYd9br7LpXV1+Emh01fHnq2Gdgrw==",
+			"license": "MIT"
+		},
 		"node_modules/ts-api-utils": {
 			"version": "2.1.0",
 			"resolved": "https://registry.npmjs.org/ts-api-utils/-/ts-api-utils-2.1.0.tgz",
@@ -4823,7 +4940,6 @@
 			"version": "6.21.0",
 			"resolved": "https://registry.npmjs.org/undici-types/-/undici-types-6.21.0.tgz",
 			"integrity": "sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ==",
-			"dev": true,
 			"license": "MIT"
 		},
 		"node_modules/unpipe": {
@@ -4957,6 +5073,22 @@
 				}
 			}
 		},
+		"node_modules/webidl-conversions": {
+			"version": "3.0.1",
+			"resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-3.0.1.tgz",
+			"integrity": "sha512-2JAn3z8AR6rjK8Sm8orRC0h/bcl/DqL7tRPdGZ4I1CjdF+EaMLmYxBHyXuKL849eucPFhvBoxMsflfOb8kxaeQ==",
+			"license": "BSD-2-Clause"
+		},
+		"node_modules/whatwg-url": {
+			"version": "5.0.0",
+			"resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-5.0.0.tgz",
+			"integrity": "sha512-saE57nupxk6v3HY35+jzBwYa0rKSy0XR8JSxZPwgLr7ys0IBzhGviA1/TUGJLmSVqs8pb9AnvICXEuOHLprYTw==",
+			"license": "MIT",
+			"dependencies": {
+				"tr46": "~0.0.3",
+				"webidl-conversions": "^3.0.0"
+			}
+		},
 		"node_modules/which": {
 			"version": "2.0.2",
 			"resolved": "https://registry.npmjs.org/which/-/which-2.0.2.tgz",
@@ -4989,6 +5121,27 @@
 			"integrity": "sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ==",
 			"dev": true,
 			"license": "ISC"
+		},
+		"node_modules/ws": {
+			"version": "8.18.2",
+			"resolved": "https://registry.npmjs.org/ws/-/ws-8.18.2.tgz",
+			"integrity": "sha512-DMricUmwGZUVr++AEAe2uiVM7UoO9MAVZMDu05UQOaUII0lp+zOzLLU4Xqh/JvTqklB1T4uELaaPBKyjE1r4fQ==",
+			"license": "MIT",
+			"engines": {
+				"node": ">=10.0.0"
+			},
+			"peerDependencies": {
+				"bufferutil": "^4.0.1",
+				"utf-8-validate": ">=5.0.2"
+			},
+			"peerDependenciesMeta": {
+				"bufferutil": {
+					"optional": true
+				},
+				"utf-8-validate": {
+					"optional": true
+				}
+			}
 		},
 		"node_modules/yaml": {
 			"version": "2.7.1",

--- a/package.json
+++ b/package.json
@@ -38,6 +38,8 @@
 		"vite": "^6.2.6"
 	},
 	"dependencies": {
+		"@supabase/ssr": "^0.6.1",
+		"@supabase/supabase-js": "^2.49.8",
 		"dotenv": "^16.5.0"
 	}
 }

--- a/src/app.d.ts
+++ b/src/app.d.ts
@@ -1,10 +1,24 @@
 // See https://svelte.dev/docs/kit/types#app.d.ts
 // for information about these interfaces
+
+import type { Session, SupabaseClient, User } from '@supabase/supabase-js';
+import type { Database } from './database.types.ts'; // import generated types
+
 declare global {
 	namespace App {
 		// interface Error {}
-		// interface Locals {}
-		// interface PageData {}
+		interface Locals {
+			supabase: SupabaseClient<Database>;
+			safeGetSession: () => Promise<{
+				session: Session | null;
+				user: User | null;
+			}>;
+			session: Session | null;
+			user: User | null;
+		}
+		interface PageData {
+			session: Session | null;
+		}
 		// interface PageState {}
 		// interface Platform {}
 	}

--- a/src/hooks.server.ts
+++ b/src/hooks.server.ts
@@ -1,0 +1,81 @@
+import { createServerClient } from '@supabase/ssr';
+import { type Handle, redirect } from '@sveltejs/kit';
+import { sequence } from '@sveltejs/kit/hooks';
+import { PUBLIC_SUPABASE_URL, PUBLIC_SUPABASE_ANON_KEY } from '$env/static/public';
+
+const supabase: Handle = async ({ event, resolve }) => {
+	/**
+	 * Creates a Supabase client specific to this server request.
+	 *
+	 * The Supabase client gets the Auth token from the request cookies.
+	 */
+	event.locals.supabase = createServerClient(PUBLIC_SUPABASE_URL, PUBLIC_SUPABASE_ANON_KEY, {
+		cookies: {
+			getAll: () => event.cookies.getAll(),
+			/**
+			 * SvelteKit's cookies API requires `path` to be explicitly set in
+			 * the cookie options. Setting `path` to `/` replicates previous/
+			 * standard behavior.
+			 */
+			setAll: (cookiesToSet) => {
+				cookiesToSet.forEach(({ name, value, options }) => {
+					event.cookies.set(name, value, { ...options, path: '/' });
+				});
+			}
+		}
+	});
+
+	/**
+	 * Unlike `supabase.auth.getSession()`, which returns the session _without_
+	 * validating the JWT, this function also calls `getUser()` to validate the
+	 * JWT before returning the session.
+	 */
+	event.locals.safeGetSession = async () => {
+		const {
+			data: { session }
+		} = await event.locals.supabase.auth.getSession();
+		if (!session) {
+			return { session: null, user: null, profile: null };
+		}
+
+		const {
+			data: { user },
+			error
+		} = await event.locals.supabase.auth.getUser();
+		if (error) {
+			// JWT validation has failed
+			return { session: null, user: null, profile: null };
+		}
+
+		return { session, user };
+	};
+
+	return resolve(event, {
+		filterSerializedResponseHeaders(name) {
+			/**
+			 * Supabase libraries use the `content-range` and `x-supabase-api-version`
+			 * headers, so we need to tell SvelteKit to pass it through.
+			 */
+			return name === 'content-range' || name === 'x-supabase-api-version';
+		}
+	});
+};
+
+const authGuard: Handle = async ({ event, resolve }) => {
+	const { session, user } = await event.locals.safeGetSession();
+	event.locals.session = session;
+	event.locals.user = user;
+
+	if (
+		!event.locals.session &&
+		event.url.pathname.length > 1 &&
+		!event.url.pathname.startsWith('/auth') &&
+		!event.url.pathname.startsWith('/resources')
+	) {
+		redirect(303, '/');
+	}
+
+	return resolve(event);
+};
+
+export const handle: Handle = sequence(supabase, authGuard);

--- a/src/lib/AdminNav.svelte
+++ b/src/lib/AdminNav.svelte
@@ -1,7 +1,0 @@
-<nav>
-	<a href="/dashboard">Dashboard</a>
-	<a href="/groups">Groups</a>
-	<a href="/">Resources</a>
-	<a href="/myaccount">My Account</a>
-	<a href="/admin">Admin Tools</a>
-</nav>

--- a/src/lib/Navbar.svelte
+++ b/src/lib/Navbar.svelte
@@ -1,0 +1,19 @@
+<script lang="ts">
+	let { data, role } = $props();
+	let { supabase } = $derived(data);
+	import { invalidate } from '$app/navigation';
+
+	const logout = async () => {
+		await supabase.auth.signOut();
+		invalidate('supabase:auth');
+	};
+</script>
+
+<nav data-sveltekit-reload>
+	<a href="/dashboard">Dashboard</a>
+	<a href="/groups">Groups</a>
+	<a href="/">Resources</a>
+	<a href="/myaccount">My Account</a>
+	{#if role === 'admin'}<a href="/admin">Admin Tools</a>{/if}
+	<a href="/" onclick={logout}>Logout</a>
+</nav>

--- a/src/lib/UserNav.svelte
+++ b/src/lib/UserNav.svelte
@@ -1,6 +1,0 @@
-<nav>
-	<a href="/dashboard">Dashboard</a>
-	<a href="/groups">Groups</a>
-	<a href="/">Resources</a>
-	<a href="/myaccount">My Account</a>
-</nav>

--- a/src/routes/+layout.server.ts
+++ b/src/routes/+layout.server.ts
@@ -1,0 +1,10 @@
+import type { LayoutServerLoad } from './$types';
+
+export const load: LayoutServerLoad = async ({ locals: { safeGetSession }, cookies }) => {
+	const { session } = await safeGetSession();
+
+	return {
+		session,
+		cookies: cookies.getAll()
+	};
+};

--- a/src/routes/+layout.svelte
+++ b/src/routes/+layout.svelte
@@ -1,17 +1,25 @@
 <script lang="ts">
 	import '../app.css';
+	import { invalidate } from '$app/navigation';
+	import { onMount } from 'svelte';
+	import Navbar from '$lib/Navbar.svelte';
 
-	import AdminNav from '$lib/AdminNav.svelte';
-	import UserNav from '$lib/UserNav.svelte';
+	let { data, children } = $props();
+	let { supabase, session, profile } = $derived(data);
 
-	let { children } = $props();
-	const role: string = 'user';
+	onMount(() => {
+		const { data } = supabase.auth.onAuthStateChange((event, newSession) => {
+			if (newSession?.expires_at && session?.expires_at) {
+				invalidate('supabase:auth');
+			}
+		});
+
+		return () => data.subscription.unsubscribe();
+	});
 </script>
 
-{#if role === 'admin'}
-	<AdminNav />
-{:else if role === 'user'}
-	<UserNav />
+{#if profile}
+	<Navbar {data} role={profile?.role} />
 {/if}
 
 {@render children()}

--- a/src/routes/+layout.ts
+++ b/src/routes/+layout.ts
@@ -1,0 +1,59 @@
+import { createBrowserClient, createServerClient, isBrowser } from '@supabase/ssr';
+
+import type { LayoutLoad } from './$types';
+
+import { PUBLIC_SUPABASE_URL, PUBLIC_SUPABASE_ANON_KEY } from '$env/static/public';
+
+export const load: LayoutLoad = async ({ data, depends, fetch }) => {
+	/**
+	 * Declare a dependency so the layout can be invalidated, for example, on
+	 * session refresh.
+	 */
+	depends('supabase:auth');
+
+	const supabase = isBrowser()
+		? createBrowserClient(PUBLIC_SUPABASE_URL, PUBLIC_SUPABASE_ANON_KEY, {
+				global: {
+					fetch
+				}
+			})
+		: createServerClient(PUBLIC_SUPABASE_URL, PUBLIC_SUPABASE_ANON_KEY, {
+				global: {
+					fetch
+				},
+				cookies: {
+					getAll() {
+						return data.cookies;
+					}
+				}
+			});
+
+	/**
+	 * It's fine to use `getSession` here, because on the client, `getSession` is
+	 * safe, and on the server, it reads `session` from the `LayoutData`, which
+	 * safely checked the session using `safeGetSession`.
+	 */
+	const {
+		data: { session }
+	} = await supabase.auth.getSession();
+
+	const {
+		data: { user }
+	} = await supabase.auth.getUser();
+
+	if (!user) {
+		return { session, supabase, user: null, profile: null };
+	}
+
+	const { data: profile, error } = await supabase
+		.from('profiles')
+		.select()
+		.eq('id', user.id)
+		.single();
+
+	if (error) {
+		console.error('Error fetching profile:', error);
+	}
+
+	return { session, supabase, user, profile };
+};

--- a/src/routes/+page.server.ts
+++ b/src/routes/+page.server.ts
@@ -1,13 +1,17 @@
 import type { PageServerLoad } from './$types';
-import * as dotenv from 'dotenv';
-dotenv.config();
+//import { BACKEND_URL } from '$env/static/private';
 
 export const load: PageServerLoad = async () => {
-	const response = await fetch(`${process.env.BACKEND_URL}`);
+	/** For fetching data from the backend 
+	 * 
+	 * 
+	const response = await fetch(`${BACKEND_URL}`);
 	const data = await response.json();
-	console.log('DATA @server:', data);
 
 	if (data) {
 		return data;
 	}
+	 *
+	 *
+	*/
 };

--- a/src/routes/+page.svelte
+++ b/src/routes/+page.svelte
@@ -2,10 +2,11 @@
 	import type { PageProps } from './$types';
 
 	let { data }: PageProps = $props();
+	let { profile } = $derived(data);
 </script>
 
 <h1>{data.message}</h1>
-<a href="/myresources">My Saved Resources</a>
+{#if profile}<a href="/myresources">My Saved Resources</a>{/if}
 <h1>Search for Resouces</h1>
 <br />
 <a href="/resources/resouceone">Resouce One</a>

--- a/src/routes/+page.svelte
+++ b/src/routes/+page.svelte
@@ -5,7 +5,6 @@
 	let { profile } = $derived(data);
 </script>
 
-<h1>{data.message}</h1>
 {#if profile}<a href="/myresources">My Saved Resources</a>{/if}
 <h1>Search for Resouces</h1>
 <br />

--- a/src/routes/admin/+page.svelte
+++ b/src/routes/admin/+page.svelte
@@ -1,4 +1,15 @@
-<a href="/admin/announcements">Announcement Manager</a>
-<a href="/admin/users">User Manager</a>
-<a href="/admin/resources">Resource Manager</a>
-<a href="/admin/support">Support Tools</a>
+<script lang="ts">
+	let { data } = $props();
+	let { profile } = $derived(data);
+</script>
+
+{#if profile.role === 'admin'}
+	<h1>Admin Dashboard</h1>
+	<a href="/admin/announcements">Announcement Manager</a>
+	<a href="/admin/users">User Manager</a>
+	<a href="/admin/resources">Resource Manager</a>
+	<a href="/admin/support">Support Tools</a>
+{:else}
+	<h1>Access Denied</h1>
+	<p>You do not have permission to access the admin dashboard.</p>
+{/if}

--- a/src/routes/admin/+page.ts
+++ b/src/routes/admin/+page.ts
@@ -1,0 +1,5 @@
+import type { PageLoad } from './$types';
+
+export const load: PageLoad = async () => {
+
+}

--- a/src/routes/admin/+page.ts
+++ b/src/routes/admin/+page.ts
@@ -1,5 +1,3 @@
 import type { PageLoad } from './$types';
 
-export const load: PageLoad = async () => {
-
-}
+export const load: PageLoad = async () => {};

--- a/src/routes/auth/+layout.svelte
+++ b/src/routes/auth/+layout.svelte
@@ -1,0 +1,5 @@
+<script lang="ts">
+	const { children } = $props();
+</script>
+
+{@render children()}

--- a/src/routes/auth/+layout.ts
+++ b/src/routes/auth/+layout.ts
@@ -1,0 +1,7 @@
+import type { LayoutLoad } from './$types';
+
+export const load: LayoutLoad = () => {
+	return {
+		skipRootLayout: true
+	};
+};

--- a/src/routes/auth/login/+page.server.ts
+++ b/src/routes/auth/login/+page.server.ts
@@ -1,0 +1,23 @@
+import { redirect } from '@sveltejs/kit';
+import { fail } from '@sveltejs/kit';
+
+import type { Actions } from './$types';
+
+export const actions: Actions = {
+	login: async ({ request, locals: { supabase } }) => {
+		const formData = await request.formData();
+		const username = formData.get('username') as string;
+		const email = formData.get('email') as string;
+		const password = formData.get('password') as string;
+
+		console.log('Login form data:', { username, email, password });
+
+		const { error } = await supabase.auth.signInWithPassword({ email, password });
+
+		if (error) {
+			return fail(400, { username, email, password, error: true, message: error.message });
+		} else {
+			redirect(303, '/dashboard');
+		}
+	}
+};

--- a/src/routes/auth/login/+page.svelte
+++ b/src/routes/auth/login/+page.svelte
@@ -1,0 +1,22 @@
+<script lang="ts">
+	import type { PageProps } from './$types';
+
+	const { form }: PageProps = $props();
+</script>
+
+<form method="POST" action="?/login">
+	{#if form?.error}<p class="error">{form?.message}</p>{/if}
+	<label>
+		Username
+		<input name="username" type="text" value={form?.username ?? ''} />
+	</label>
+	<label>
+		Email
+		<input name="email" type="email" value={form?.email ?? ''} />
+	</label>
+	<label>
+		Password
+		<input name="password" type="password" value={form?.password ?? ''} />
+	</label>
+	<button class="button">Log In</button>
+</form>

--- a/src/routes/auth/signup/+page.server.ts
+++ b/src/routes/auth/signup/+page.server.ts
@@ -1,0 +1,34 @@
+import { redirect } from '@sveltejs/kit';
+import { fail } from '@sveltejs/kit';
+
+import type { Actions } from './$types';
+
+export const actions: Actions = {
+	signup: async ({ request, locals: { supabase } }) => {
+		const formData = await request.formData();
+		const invite = formData.get('invite') as string;
+		const username = formData.get('username') as string;
+		const email = formData.get('email') as string;
+		const password = formData.get('password') as string;
+		const passwordCheck = formData.get('password-check') as string;
+
+		console.log('Signup form data:', { invite, username, email, password, passwordCheck });
+
+		if (invite !== '11') {
+			return fail(400, { username, email, password, passwordCheck, inviteWrong: true });
+		}
+
+		if (password !== passwordCheck) {
+			return fail(400, { invite, username, email, passwordMismatch: true });
+		}
+
+		const { error } = await supabase.auth.signUp({ email, password });
+
+		if (error) {
+			console.error('Signup error:', error);
+			redirect(303, '/auth/error');
+		} else {
+			redirect(303, '/dashboard');
+		}
+	}
+};

--- a/src/routes/auth/signup/+page.svelte
+++ b/src/routes/auth/signup/+page.svelte
@@ -1,0 +1,31 @@
+<script lang="ts">
+	import type { PageProps } from './$types';
+
+	const { form }: PageProps = $props();
+</script>
+
+<form method="POST" action="?/signup">
+	{#if form?.inviteWrong}<p class="error">Invite Code Not Found</p>{/if}
+	<label>
+		Invite Code
+		<input name="invite" type="text" value={form?.invite ?? ''} />
+	</label>
+	<label>
+		Username
+		<input name="username" type="text" value={form?.username ?? ''} />
+	</label>
+	<label>
+		Email
+		<input name="email" type="email" value={form?.email ?? ''} />
+	</label>
+	{#if form?.passwordMismatch}<p class="error">Passwords Do Not Match</p>{/if}
+	<label>
+		Password
+		<input name="password" type="password" value={form?.password ?? ''} />
+	</label>
+	<label>
+		Confirm Password
+		<input name="password-check" type="password" value={form?.passwordCheck ?? ''} />
+	</label>
+	<button>Complete Sign Up</button>
+</form>

--- a/src/routes/myaccount/+page.svelte
+++ b/src/routes/myaccount/+page.svelte
@@ -1,3 +1,9 @@
+<script lang="ts">
+	let { data } = $props();
+	let { profile } = $derived(data);
+</script>
+
 <p>Details and such</p>
+<p>Role: {profile.role}</p>
 <a href="/myaccount/edit">Edit</a>
 <a href="/">Back</a>


### PR DESCRIPTION
## 📌 Summary

Adds front end authentication, saves session, user and profile data.
Adds login page at ```/auth/login```
Protects routes with specific access permissions
Displays correct Navbar depending on what role a user has

---

## 📁 What's Changed (in the front end)

<!-- High-level bullet points of major changes -->

- 1 Session, User and Profile Data and Supabase client
   - On the client side ```/src/routes/+layout.ts``` gets the session, user and profile data from supabase auth as well as the supabase client
   - On the server side ```/src/hooks.server.ts``` defines ```safeGetSession()``` that can be used to get session and user data but not the profile data
   - Data can be accessed in any +page.svelte or +layout.svelte by using
     ```
        let { data } = $props();
        let { session, supabase, user, profile } = $derived(data)
     ```
- 2 Route Protection
    - ``` /src/hooks.server.ts ``` defines ```authGuard()``` which checks if there is a session and a user.
        It redirects to ```/``` if a non logged in user accesses any pages that are not ```/``` or ```/resouces/[slug]```
    - ```/src/routes/+layout.svelte``` checks if a profile has been logged in, and if so checks the role.
        It then displays either no Navbar (not logged in), a Navbar **without** the Admin Tools link (user logged in), or a Navbar **with** that link (admin logged in)
    - ```/src/routes/admin/+page.svelte``` checks if a profile has the admin role.
        It then displays admin links or text saying 'You don't have permission to be here'

- 3 .env Changes
    - ```.env``` needs to be renamed to ```.env.local```
    - ```PUBLIC_SUPABASE_URL``` and ```PUBLIC_SUPABASE_ANON_KEY``` need to be added. Both can be found on the Supabase platform, I will also put them in the discord sst channel
    - We no longer need **dotenv**
    - env variables can now be imported in using
      ``` import { [VARIABLE_NAME] } from '$env/static/public' ```
---

## 🧪 How to Test

<!-- Instructions for reviewers to test this PR -->

1. Change .env to .env.local
2. Add new env variables
3. Run `npm install` (if new packages added)
4. Run `npm run dev`
5. Navigate to `/auth/login` 
   - User Login -> email: me@me.com, password: mepass
   - Admin Login -> email: admin@me.com, password: adminpass

---

## 📋 Checklist

<!-- Tick all that apply -->

- [x] Code compiles and runs
- [x] Tests pass
- [x] Linting passes (`npm run lint`)
- [ ] No console warnings or errors
- [ ] UI looks good on all screen sizes
- [ ] Reviewed by at least one team member

---

## 🧠 Notes for Reviewers

<!-- Anything reviewers should pay extra attention to -->

e.g. Check if component is accessible with keyboard/tab navigation.
